### PR TITLE
feat: Add GitHub Action for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release Extension
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  push:
+    branches:
+      - main # Triggers on pushes to the main branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Build extension
+        run: ./gradlew bwextension
+
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: WigAI.bwextension
+          path: build/extensions/WigAI.bwextension
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for changelog generation
+
+      - name: Download extension artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: WigAI.bwextension
+          # path: default path is fine, it will be in a directory named after the artifact
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' 
+
+      - name: Install conventional-changelog-cli
+        run: npm install -g conventional-changelog-cli conventional-commits-parser
+
+      - name: Generate release notes
+        run: conventional-changelog -p angular -o RELEASE_NOTES.md -s -r 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: release-$(date +'%Y%m%d%H%M%S')
+          name: Release $(date +'%Y.%m.%d-%H%M%S')
+          body_path: RELEASE_NOTES.md
+          files: WigAI.bwextension/WigAI.bwextension # Path to the downloaded artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`.github/workflows/release.yml`) to automate the process of building and releasing the `.bwextension` file.

The workflow consists of two main jobs:

1.  **Build Job:**
    *   Triggers on manual dispatch (`workflow_dispatch`) or pushes to the `main` branch.
    *   Checks out the repository code.
    *   Sets up JDK 21 and Gradle.
    *   Executes the `./gradlew bwextension` task to build the `WigAI.bwextension` file.
    *   Uploads the `WigAI.bwextension` file as a build artifact.

2.  **Release Job:**
    *   Depends on the successful completion of the `build` job.
    *   Downloads the `WigAI.bwextension` artifact.
    *   Checks out the full commit history.
    *   Sets up Node.js.
    *   Installs `conventional-changelog-cli`.
    *   Generates release notes (as `RELEASE_NOTES.md`) from conventional commit messages since the last release.
    *   Creates a new GitHub Release:
        *   Tags the release with a timestamp (e.g., `release-YYYYMMDDHHMMSS`).
        *   Uses the generated notes as the release body.
        *   Attaches the `WigAI.bwextension` file as a release asset.

This workflow will streamline the release process, ensuring that each release is consistently built and includes a changelog based on commit history.