### PR TITLE
fix: Correct conventional-changelog command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm install -g conventional-changelog-cli conventional-commits-parser
 
       - name: Generate release notes
-        run: conventional-changelog -p angular -o RELEASE_NOTES.md -s -r 0
+        run: conventional-changelog -p angular -i CHANGELOG.md -s -o RELEASE_NOTES.md -r 0 && cat RELEASE_NOTES.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The previous command for generating release notes was failing because the -s (same-file) flag requires the -i (infile) flag to be explicitly provided.

This commit updates the command to:
`conventional-changelog -p angular -i CHANGELOG.md -s -o RELEASE_NOTES.md -r 0 && cat RELEASE_NOTES.md`

This ensures that conventional-changelog reads from CHANGELOG.md (even if it's new or empty), processes it, and writes the output to RELEASE_NOTES.md, which is then used for the GitHub release body. The `cat RELEASE_NOTES.md` is added for debugging purposes to see the generated notes in the workflow logs.