### PR TITLE
fix: Use output redirection for conventional-changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm install -g conventional-changelog-cli conventional-commits-parser
 
       - name: Generate release notes
-        run: conventional-changelog -p angular -i CHANGELOG.md -s -o RELEASE_NOTES.md -r 0 && cat RELEASE_NOTES.md
+        run: conventional-changelog -p angular -i CHANGELOG.md -s -r 0 > RELEASE_NOTES.md && cat RELEASE_NOTES.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The `conventional-changelog` command was still not producing the `RELEASE_NOTES.md` file correctly when using the -o and -s flags together.

This commit changes the command to use standard output redirection: `conventional-changelog -p angular -i CHANGELOG.md -s -r 0 > RELEASE_NOTES.md && cat RELEASE_NOTES.md`

This ensures that the output of the `conventional-changelog` script is properly captured in the `RELEASE_NOTES.md` file, which is then used for the GitHub release body. The `cat RELEASE_NOTES.md` remains for debugging purposes in the workflow logs.