### PR TITLE
fix: Correct artifact path and add permissions for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main # Triggers on pushes to the main branch
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -44,7 +47,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: WigAI.bwextension
-          # path: default path is fine, it will be in a directory named after the artifact
+          path: . # Download directly into the current workspace directory
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -63,6 +66,6 @@ jobs:
           tag_name: release-$(date +'%Y%m%d%H%M%S')
           name: Release $(date +'%Y.%m.%d-%H%M%S')
           body_path: RELEASE_NOTES.md
-          files: WigAI.bwextension/WigAI.bwextension # Path to the downloaded artifact
+          files: WigAI.bwextension # Updated path
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit addresses two issues in the GitHub Actions release workflow:

1.  **Artifact Path:** The `actions/download-artifact` step has been modified to download the `WigAI.bwextension` directly into the workspace root by setting `path: .`. The `softprops/action-gh-release` step has been updated accordingly to look for `WigAI.bwextension` in the root. This resolves the "Pattern does not match any files" error.

2.  **Release Permissions:** A top-level `permissions` block has been added to the workflow file, granting `contents: write` permission. This is necessary for the `softprops/action-gh-release` action to create GitHub releases and should resolve the 403 Forbidden error.