### PR TITLE
fix: Correct dynamic tag generation for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,15 @@ jobs:
       - name: Generate release notes
         run: conventional-changelog -p angular -i CHANGELOG.md -s -r 0 > RELEASE_NOTES.md && cat RELEASE_NOTES.md
 
+      - name: Generate tag name
+        id: generate_tag # id is not strictly needed here as we are using GITHUB_ENV but good practice
+        run: echo "TAG_NAME=release-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: release-$(date +'%Y%m%d%H%M%S')
-          name: Release $(date +'%Y.%m.%d-%H%M%S')
+          tag_name: ${{ env.TAG_NAME }}
+          name: Release ${{ env.TAG_NAME }}
           body_path: RELEASE_NOTES.md
           files: WigAI.bwextension # Updated path
         env:


### PR DESCRIPTION
The `tag_name` for releases was not being generated correctly because the `$(date ...)` command was not evaluated within the `with` block of the `softprops/action-gh-release` step.

This commit fixes the issue by:
1. Adding a new step "Generate tag name" that executes `date` and stores the output (e.g., `release-YYYYMMDDHHMMSS`) in the `TAG_NAME` environment variable via `$GITHUB_ENV`.
2. Updating the `Create GitHub Release` step to use `${{ env.TAG_NAME }}` for both the `tag_name` and the release `name` properties.

This ensures that a valid, dynamically generated tag is used for each release.