### PR TITLE
Update Shadow plugin to com.gradleup.shadow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.bundling.Zip
 plugins {
     // Apply the Java plugin to add support for Java
     java
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.3.0"
 }
 
 group = "io.github.fabb"


### PR DESCRIPTION

I've updated the Shadow plugin to `com.gradleup.shadow`.

I replaced the deprecated `com.github.johnrengelman.shadow` plugin with its successor, `com.gradleup.shadow`. I also updated the plugin version to 8.3.0, which is a recent stable version. I then confirmed that your build was successful with the new plugin and version.