### PR TITLE
feat: add next_project and previous_project MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,21 @@
 
 For details refer to these documents:
 
--   [Project Brief](/_bmad-output/planning-artifacts/project-brief.md)
--   [PRD](/_bmad-output/planning-artifacts/prd.md)
--   [Architecture](/_bmad-output/planning-artifacts/architecture.md)
+-   [Project Brief](_bmad-output/planning-artifacts/project-brief.md)
+-   [PRD](_bmad-output/planning-artifacts/prd/index.md)
+-   [Architecture](_bmad-output/planning-artifacts/architecture.md)
 
 ## Commands
 
 ```bash
-./gradlew build        # compile + shadowJar + WigAI.bwextension → build/extensions/WigAI.bwextension
-./gradlew test         # run unit tests (JUnit Jupiter)
+# Build requires a real JDK 21 — the system `java` is a JRE (no javac) and no
+# Gradle toolchain is configured, so JAVA_HOME must point at a JDK 21 install.
+JAVA_HOME=/path/to/jdk-21 ./gradlew build   # → build/extensions/WigAI.bwextension
+JAVA_HOME=/path/to/jdk-21 ./gradlew test    # JUnit Jupiter unit tests
+
+# Deploy to the running Bitwig, then toggle the WigAI controller off/on
+# (or restart Bitwig) to load the new build:
+cp build/extensions/WigAI.bwextension ~/"Bitwig Studio/Extensions/"
 ```
 
 ## Architecture
@@ -20,7 +26,7 @@ Java 21 Gradle project. Source root: `src/main/java/io/github/fabb/wigai/`
 | Package | Purpose |
 |---------|---------|
 | `bitwig/` | `BitwigApiFacade` — wraps all Bitwig Extension API calls |
-| `features/` | Domain controllers (`TransportController`, `DeviceController`, `ClipSceneController`) |
+| `features/` | Domain controllers (`TransportController`, `DeviceController`, `ClipSceneController`, `ProjectController`) |
 | `mcp/tool/` | One class per MCP tool (registered via MCP Java SDK) |
 | `mcp/` | `McpServerManager`, `McpErrorHandler` |
 | `config/` | `ConfigManager` interface + `PreferencesBackedConfigManager` |
@@ -35,7 +41,9 @@ Entry point: `WigAIExtension.java` / `WigAIExtensionDefinition.java`
 - Logging: `host.println()` → visible in Bitwig's extension console (not stdout)
 - MCP Java SDK docs: use `context7` tool (also noted in `build.gradle.kts`)
 - Bitwig extension API: `com.bitwig:extension-api:19`
+- The project targets API **v19**, but the host Bitwig may run a newer level (e.g. v24) — newer host, older compile target.
+- **Verify API behavior against a *running* Bitwig, not mocks.** Mocked unit tests validate your *model* of the async push/flush API, not the API itself — a passing mock test has shipped live-broken behavior here before.
 
 ## Rules
 
-Never read `bitwig-api-doc-scraper/bitwig-api-documentation.md` fully into context since it's too big. Rather only read parts of it using code search tools.
+Never read the scraped API doc (`bitwig-api-doc-scraper/bitwig-api-documentation.md`, a **gitignored, generated** artifact — run the scraper to produce it) fully into context; it's too big. Search it with code-search tools instead.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The extension enables external AI agents (e.g., IDE-based copilots, standalone A
 -   Transport control (start/stop playback)
 -   Device parameter control for selected devices
 -   Clip and scene launching
+-   Switching between open projects
 
 ## Requirements
 

--- a/src/main/java/io/github/fabb/wigai/bitwig/BitwigApiFacade.java
+++ b/src/main/java/io/github/fabb/wigai/bitwig/BitwigApiFacade.java
@@ -328,6 +328,22 @@ public class BitwigApiFacade {
     }
 
     /**
+     * Switches to the next open project tab in Bitwig.
+     */
+    public void nextProject() {
+        logger.info("BitwigApiFacade: Switching to next project");
+        application.nextProject();
+    }
+
+    /**
+     * Switches to the previous open project tab in Bitwig.
+     */
+    public void previousProject() {
+        logger.info("BitwigApiFacade: Switching to previous project");
+        application.previousProject();
+    }
+
+    /**
      * Get the ControllerHost instance.
      *
      * @return The ControllerHost

--- a/src/main/java/io/github/fabb/wigai/common/error/ErrorCode.java
+++ b/src/main/java/io/github/fabb/wigai/common/error/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     BITWIG_TIMEOUT("BITWIG_TIMEOUT", "Bitwig API operation timed out"),
     DEVICE_UNAVAILABLE("DEVICE_UNAVAILABLE", "Device is not available or responding"),
     TRANSPORT_ERROR("TRANSPORT_ERROR", "Transport operation failed"),
+    PROJECT_ERROR("PROJECT_ERROR", "Project operation failed"),
 
     // System Errors
     INTERNAL_ERROR("INTERNAL_ERROR", "Internal system error occurred"),

--- a/src/main/java/io/github/fabb/wigai/features/ProjectController.java
+++ b/src/main/java/io/github/fabb/wigai/features/ProjectController.java
@@ -1,0 +1,58 @@
+package io.github.fabb.wigai.features;
+
+import io.github.fabb.wigai.bitwig.BitwigApiFacade;
+import io.github.fabb.wigai.common.Logger;
+import io.github.fabb.wigai.common.error.BitwigApiException;
+import io.github.fabb.wigai.common.error.ErrorCode;
+
+/**
+ * Controller class for project-level features.
+ * Bridges between MCP tools and Bitwig API operations for switching between open projects.
+ */
+public class ProjectController {
+    private final BitwigApiFacade bitwigApiFacade;
+    private final Logger logger;
+
+    /**
+     * Creates a new ProjectController instance.
+     *
+     * @param bitwigApiFacade The facade for Bitwig API interactions
+     * @param logger          The logger for logging operations
+     */
+    public ProjectController(BitwigApiFacade bitwigApiFacade, Logger logger) {
+        this.bitwigApiFacade = bitwigApiFacade;
+        this.logger = logger;
+    }
+
+    /**
+     * Switches to the next open project tab.
+     *
+     * @return A message indicating the operation result
+     */
+    public String nextProject() {
+        try {
+            logger.info("ProjectController: Switching to next project");
+            bitwigApiFacade.nextProject();
+            return "Switched to next project.";
+        } catch (Exception e) {
+            logger.info("ProjectController: Error switching to next project: " + e.getMessage());
+            throw new BitwigApiException(ErrorCode.PROJECT_ERROR, "nextProject", "Failed to switch to next project", e);
+        }
+    }
+
+    /**
+     * Switches to the previous open project tab.
+     *
+     * @return A message indicating the operation result
+     */
+    public String previousProject() {
+        try {
+            logger.info("ProjectController: Switching to previous project");
+            bitwigApiFacade.previousProject();
+            return "Switched to previous project.";
+        } catch (Exception e) {
+            logger.info("ProjectController: Error switching to previous project: " + e.getMessage());
+            throw new BitwigApiException(ErrorCode.PROJECT_ERROR, "previousProject", "Failed to switch to previous project", e);
+        }
+    }
+}

--- a/src/main/java/io/github/fabb/wigai/mcp/McpServerManager.java
+++ b/src/main/java/io/github/fabb/wigai/mcp/McpServerManager.java
@@ -8,12 +8,14 @@ import io.github.fabb.wigai.config.ConfigManager;
 import io.github.fabb.wigai.features.TransportController;
 import io.github.fabb.wigai.features.DeviceController;
 import io.github.fabb.wigai.features.ClipSceneController;
+import io.github.fabb.wigai.features.ProjectController;
 import io.modelcontextprotocol.server.*;
 import io.modelcontextprotocol.server.transport.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.jetty.servlet.ServletHolder;
 import io.github.fabb.wigai.mcp.tool.StatusTool;
 import io.github.fabb.wigai.mcp.tool.TransportTool;
+import io.github.fabb.wigai.mcp.tool.ProjectTool;
 import io.github.fabb.wigai.mcp.tool.DeviceParamTool;
 import io.github.fabb.wigai.mcp.tool.ClipTool;
 import io.github.fabb.wigai.mcp.tool.SceneTool;
@@ -52,6 +54,7 @@ public class McpServerManager {
     private TransportController transportController;
     private DeviceController deviceController;
     private ClipSceneController clipSceneController;
+    private ProjectController projectController;
 
     /**
      * Creates a new McpServerManager instance.
@@ -124,6 +127,7 @@ public class McpServerManager {
             transportController = new TransportController(bitwigApiFacade, logger);
             deviceController = new DeviceController(bitwigApiFacade, logger);
             clipSceneController = new ClipSceneController(bitwigApiFacade, logger);
+            projectController = new ProjectController(bitwigApiFacade, logger);
         } else {
             logger.info("McpServerManager: Reusing existing Bitwig API controllers");
         }
@@ -141,6 +145,8 @@ public class McpServerManager {
                 StatusTool.specification(this.extensionDefinition, bitwigApiFacade, structuredLogger),
                 TransportTool.transportStartSpecification(transportController, structuredLogger),
                 TransportTool.transportStopSpecification(transportController, structuredLogger),
+                ProjectTool.nextProjectSpecification(projectController, structuredLogger),
+                ProjectTool.previousProjectSpecification(projectController, structuredLogger),
                 ClipTool.launchClipSpecification(clipSceneController, structuredLogger),
                 SceneTool.launchSceneByIndexSpecification(clipSceneController, structuredLogger),
                 SceneByNameTool.launchSceneByNameSpecification(clipSceneController, structuredLogger),

--- a/src/main/java/io/github/fabb/wigai/mcp/tool/ProjectTool.java
+++ b/src/main/java/io/github/fabb/wigai/mcp/tool/ProjectTool.java
@@ -1,0 +1,102 @@
+package io.github.fabb.wigai.mcp.tool;
+
+import io.github.fabb.wigai.common.logging.StructuredLogger;
+import io.github.fabb.wigai.features.ProjectController;
+import io.github.fabb.wigai.mcp.McpErrorHandler;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * MCP tools for switching between open projects in Bitwig using the unified error handling architecture.
+ *
+ * <p>Bitwig's extension API only supports cycling through the projects that are already open
+ * (Application#nextProject / Application#previousProject); it cannot open a project from disk or
+ * jump to a specific project by name/index.
+ */
+public class ProjectTool {
+
+    /**
+     * Creates a "next_project" tool specification using the unified error handling system.
+     *
+     * @param projectController The controller for project operations
+     * @param logger            The structured logger for logging operations
+     * @return A SyncToolSpecification for the "next_project" tool
+     */
+    public static McpServerFeatures.SyncToolSpecification nextProjectSpecification(
+            ProjectController projectController, StructuredLogger logger) {
+
+        var schema = """
+            {
+              "type": "object",
+              "properties": {}
+            }""";
+        var tool = McpSchema.Tool.builder()
+            .name("next_project")
+            .description("Switch to the next open project tab in Bitwig. Cycles through already-open projects; does not open projects from disk. With only one project open this is a no-op.")
+            .inputSchema(schema)
+            .build();
+
+        BiFunction<McpSyncServerExchange, CallToolRequest, McpSchema.CallToolResult> handler =
+            (exchange, req) -> McpErrorHandler.executeWithErrorHandling(
+                "next_project",
+                logger,
+                () -> {
+                    String resultMessage = projectController.nextProject();
+                    return Map.of(
+                        "action", "project_switched_next",
+                        "message", resultMessage
+                    );
+                }
+            );
+
+        return McpServerFeatures.SyncToolSpecification.builder()
+            .tool(tool)
+            .callHandler(handler)
+            .build();
+    }
+
+    /**
+     * Creates a "previous_project" tool specification using the unified error handling system.
+     *
+     * @param projectController The controller for project operations
+     * @param logger            The structured logger for logging operations
+     * @return A SyncToolSpecification for the "previous_project" tool
+     */
+    public static McpServerFeatures.SyncToolSpecification previousProjectSpecification(
+            ProjectController projectController, StructuredLogger logger) {
+
+        var schema = """
+            {
+              "type": "object",
+              "properties": {}
+            }""";
+        var tool = McpSchema.Tool.builder()
+            .name("previous_project")
+            .description("Switch to the previous open project tab in Bitwig. Cycles through already-open projects; does not open projects from disk. With only one project open this is a no-op.")
+            .inputSchema(schema)
+            .build();
+
+        BiFunction<McpSyncServerExchange, CallToolRequest, McpSchema.CallToolResult> handler =
+            (exchange, req) -> McpErrorHandler.executeWithErrorHandling(
+                "previous_project",
+                logger,
+                () -> {
+                    String resultMessage = projectController.previousProject();
+                    return Map.of(
+                        "action", "project_switched_previous",
+                        "message", resultMessage
+                    );
+                }
+            );
+
+        return McpServerFeatures.SyncToolSpecification.builder()
+            .tool(tool)
+            .callHandler(handler)
+            .build();
+    }
+}

--- a/src/test/java/io/github/fabb/wigai/bitwig/BitwigApiFacadeTest.java
+++ b/src/test/java/io/github/fabb/wigai/bitwig/BitwigApiFacadeTest.java
@@ -284,6 +284,30 @@ public class BitwigApiFacadeTest {
     }
 
     @Test
+    void testNextProject() {
+        // Execute the facade method
+        bitwigApiFacade.nextProject();
+
+        // Verify the application.nextProject() was called
+        verify(mockApplication).nextProject();
+
+        // Verify logging
+        verify(mockLogger).info("BitwigApiFacade: Switching to next project");
+    }
+
+    @Test
+    void testPreviousProject() {
+        // Execute the facade method
+        bitwigApiFacade.previousProject();
+
+        // Verify the application.previousProject() was called
+        verify(mockApplication).previousProject();
+
+        // Verify logging
+        verify(mockLogger).info("BitwigApiFacade: Switching to previous project");
+    }
+
+    @Test
     void testSetSelectedDeviceParameter_Success() {
         // Arrange
         int parameterIndex = 3;

--- a/src/test/java/io/github/fabb/wigai/features/ProjectControllerTest.java
+++ b/src/test/java/io/github/fabb/wigai/features/ProjectControllerTest.java
@@ -1,0 +1,83 @@
+package io.github.fabb.wigai.features;
+
+import io.github.fabb.wigai.bitwig.BitwigApiFacade;
+import io.github.fabb.wigai.common.Logger;
+import io.github.fabb.wigai.common.error.BitwigApiException;
+import io.github.fabb.wigai.common.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the ProjectController class.
+ */
+public class ProjectControllerTest {
+
+    @Mock
+    private BitwigApiFacade mockBitwigApiFacade;
+
+    @Mock
+    private Logger mockLogger;
+
+    private ProjectController projectController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        projectController = new ProjectController(mockBitwigApiFacade, mockLogger);
+    }
+
+    @Test
+    void testNextProject() {
+        String result = projectController.nextProject();
+
+        assertEquals("Switched to next project.", result);
+        verify(mockBitwigApiFacade).nextProject();
+        verify(mockLogger).info("ProjectController: Switching to next project");
+    }
+
+    @Test
+    void testNextProjectWithException() {
+        doThrow(new RuntimeException("Test exception")).when(mockBitwigApiFacade).nextProject();
+
+        BitwigApiException exception = assertThrows(BitwigApiException.class, () -> {
+            projectController.nextProject();
+        });
+
+        assertEquals(ErrorCode.PROJECT_ERROR, exception.getErrorCode());
+        assertEquals("nextProject", exception.getOperation());
+        assertTrue(exception.getMessage().contains("Failed to switch to next project"));
+
+        verify(mockLogger).info("ProjectController: Switching to next project");
+        verify(mockLogger).info(contains("ProjectController: Error switching to next project"));
+    }
+
+    @Test
+    void testPreviousProject() {
+        String result = projectController.previousProject();
+
+        assertEquals("Switched to previous project.", result);
+        verify(mockBitwigApiFacade).previousProject();
+        verify(mockLogger).info("ProjectController: Switching to previous project");
+    }
+
+    @Test
+    void testPreviousProjectWithException() {
+        doThrow(new RuntimeException("Test exception")).when(mockBitwigApiFacade).previousProject();
+
+        BitwigApiException exception = assertThrows(BitwigApiException.class, () -> {
+            projectController.previousProject();
+        });
+
+        assertEquals(ErrorCode.PROJECT_ERROR, exception.getErrorCode());
+        assertEquals("previousProject", exception.getOperation());
+        assertTrue(exception.getMessage().contains("Failed to switch to previous project"));
+
+        verify(mockLogger).info("ProjectController: Switching to previous project");
+        verify(mockLogger).info(contains("ProjectController: Error switching to previous project"));
+    }
+}

--- a/src/test/java/io/github/fabb/wigai/mcp/tool/ProjectToolTest.java
+++ b/src/test/java/io/github/fabb/wigai/mcp/tool/ProjectToolTest.java
@@ -1,0 +1,125 @@
+package io.github.fabb.wigai.mcp.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.fabb.wigai.common.Logger;
+import io.github.fabb.wigai.common.error.BitwigApiException;
+import io.github.fabb.wigai.common.error.ErrorCode;
+import io.github.fabb.wigai.mcp.McpErrorHandler;
+import io.github.fabb.wigai.common.logging.StructuredLogger;
+import io.github.fabb.wigai.features.ProjectController;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+/**
+ * Unit tests for ProjectTool using the unified error handling architecture.
+ */
+class ProjectToolTest {
+
+    @Mock
+    private ProjectController projectController;
+    @Mock
+    private StructuredLogger structuredLogger;
+    @Mock
+    private Logger baseLogger;
+    @Mock
+    private StructuredLogger.TimedOperation timedOperation;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(structuredLogger.getBaseLogger()).thenReturn(baseLogger);
+        when(structuredLogger.generateOperationId()).thenReturn("op-123");
+        when(structuredLogger.startTimedOperation(any(), any(), any())).thenReturn(timedOperation);
+    }
+
+    @Test
+    void testNextProjectSpecification() {
+        McpServerFeatures.SyncToolSpecification spec = ProjectTool.nextProjectSpecification(projectController, structuredLogger);
+
+        assertNotNull(spec);
+        assertNotNull(spec.tool());
+        assertEquals("next_project", spec.tool().name());
+        assertTrue(spec.tool().description().contains("next"));
+        assertNotNull(spec.tool().inputSchema());
+    }
+
+    @Test
+    void testPreviousProjectSpecification() {
+        McpServerFeatures.SyncToolSpecification spec = ProjectTool.previousProjectSpecification(projectController, structuredLogger);
+
+        assertNotNull(spec);
+        assertNotNull(spec.tool());
+        assertEquals("previous_project", spec.tool().name());
+        assertTrue(spec.tool().description().contains("previous"));
+        assertNotNull(spec.tool().inputSchema());
+    }
+
+    @Test
+    void testNextProjectSuccessResponseFormat() throws Exception {
+        when(projectController.nextProject()).thenReturn("Switched to next project.");
+
+        Map<String, Object> responseData = Map.of(
+            "action", "project_switched_next",
+            "message", "Switched to next project."
+        );
+        McpSchema.CallToolResult result = McpErrorHandler.createSuccessResponse(responseData);
+
+        JsonNode dataNode = McpResponseTestUtils.validateActionResponse(result, "project_switched_next");
+        assertEquals("Switched to next project.", dataNode.get("message").asText());
+    }
+
+    @Test
+    void testPreviousProjectSuccessResponseFormat() throws Exception {
+        when(projectController.previousProject()).thenReturn("Switched to previous project.");
+
+        Map<String, Object> responseData = Map.of(
+            "action", "project_switched_previous",
+            "message", "Switched to previous project."
+        );
+        McpSchema.CallToolResult result = McpErrorHandler.createSuccessResponse(responseData);
+
+        JsonNode dataNode = McpResponseTestUtils.validateActionResponse(result, "project_switched_previous");
+        assertEquals("Switched to previous project.", dataNode.get("message").asText());
+    }
+
+    @Test
+    void testProjectErrorResponseFormat() throws Exception {
+        BitwigApiException exception = new BitwigApiException(
+            ErrorCode.PROJECT_ERROR,
+            "nextProject",
+            "Project switching is not available"
+        );
+
+        McpSchema.CallToolResult result = McpErrorHandler.createErrorResponse(exception, structuredLogger);
+
+        JsonNode errorNode = McpResponseTestUtils.validateErrorResponse(result);
+        assertEquals("PROJECT_ERROR", errorNode.get("code").asText());
+        assertEquals("Project switching is not available", errorNode.get("message").asText());
+        assertEquals("nextProject", errorNode.get("operation").asText());
+    }
+
+    @Test
+    void testProjectResponseNotDoubleWrapped() throws Exception {
+        Map<String, Object> actionData = Map.of(
+            "action", "project_switched_next",
+            "message", "Switched to next project."
+        );
+        McpSchema.CallToolResult result = McpErrorHandler.createSuccessResponse(actionData);
+
+        McpResponseTestUtils.assertNotDoubleWrapped(result);
+
+        JsonNode dataNode = McpResponseTestUtils.validateActionResponse(result, "project_switched_next");
+        assertEquals("Switched to next project.", dataNode.get("message").asText());
+    }
+}


### PR DESCRIPTION
## Summary
Adds two MCP tools, `next_project` and `previous_project`, that let an AI agent cycle between the projects currently open in Bitwig, by wrapping the extension API's `Application#nextProject()` / `#previousProject()`.

Relates to #2 (Think about MCP Tools).

## Implementation
Mirrors the existing transport tooling end-to-end, so it slots into the established architecture:
- `BitwigApiFacade#nextProject()` / `#previousProject()`
- `ProjectController` — thin controller (like `TransportController`); wraps failures in `BitwigApiException(PROJECT_ERROR)`
- `ProjectTool` — `next_project` / `previous_project` `SyncToolSpecification`s
- New `ErrorCode.PROJECT_ERROR`
- Both tools registered in `McpServerManager`
- Success responses use distinct event actions (`project_switched_next` / `project_switched_previous`), consistent with `transport_started` etc.

## Scope / API limitations
The controller extension API only *cycles* already-open project tabs — it cannot open a project from disk, jump to a specific project by name/index, or report how many projects are open. With a single project open the calls are no-ops (documented in the tool descriptions). A by-name variant was intentionally left out, since reliably confirming a switch isn't possible with the current API surface.

## Testing
- Unit tests at the facade, controller, and tool layers (mirrors the transport test suite); full build + tests pass on JDK 21.
- Manually verified against Bitwig Studio 5.3.13: with two projects open, driving `next_project` / `previous_project` over the live MCP server flips the active project (confirmed via the `status` tool's `project_name`).

— Written by Claude Code (Opus 4.8) on behalf of @0reo